### PR TITLE
Fix white-on-white contrast in Who Benefits section

### DIFF
--- a/docs/site/doc/landingpage.gsp
+++ b/docs/site/doc/landingpage.gsp
@@ -51,6 +51,11 @@
     .td-box--5 h2, .td-box--5 h4, .td-box--5 p, .td-box--5 li {
         color: white !important;
     }
+    /* Fix white-on-white contrast: make cards semi-transparent to show gradient */
+    .td-box--5 .card {
+        background: rgba(255, 255, 255, 0.1) !important;
+        border: 1px solid rgba(255, 255, 255, 0.2) !important;
+    }
 
     /* Screenshot/demo image styling */
     .demo-screenshot {


### PR DESCRIPTION
## Summary
Fixes #21

## Changes
- Added CSS rule to make cards in 'Who Benefits?' section semi-transparent
- Cards now use `rgba(255, 255, 255, 0.1)` background
- Purple gradient shows through while maintaining card structure
- Semi-transparent border `rgba(255, 255, 255, 0.2)` provides subtle definition

## Problem Solved
Previously white Bootstrap cards on purple gradient background made white text invisible. Now cards have 10% opacity allowing gradient to show through while text remains readable.

## Testing
- [x] CSS changes implemented in `docs/site/doc/landingpage.gsp`
- [x] Feature branch pushed
- [ ] Visual verification pending deployment

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>