### PR TITLE
Fix broken documentation links on landing page

### DIFF
--- a/docs/site/doc/landingpage.gsp
+++ b/docs/site/doc/landingpage.gsp
@@ -87,7 +87,7 @@
             <a class="btn btn-lg btn-light me-3 mb-3" href="https://github.com/raifdmueller/asciidoc-mcp">
                 <i class="fab fa-github"></i> View on GitHub
             </a>
-            <a class="btn btn-lg btn-warning mb-3" href="${content.rootpath}arc42-template.html">
+            <a class="btn btn-lg btn-warning mb-3" href="${content.rootpath}arc42/01_introduction.html">
                 <i class="fas fa-book"></i> Read Documentation
             </a>
         </div>
@@ -180,7 +180,7 @@ pip install -r requirements.txt</code></pre>
         <div class="row mt-4">
             <div class="col-md-12 text-center">
                 <p class="lead">That's it! The server will auto-start and open a web interface.</p>
-                <a class="btn btn-primary" href="${content.rootpath}arc42-template.html">
+                <a class="btn btn-primary" href="${content.rootpath}arc42/01_introduction.html">
                     Read the full documentation →
                 </a>
             </div>


### PR DESCRIPTION
## Summary
Fixes #20

## Problem
Two documentation links on the landing page returned 404 errors because they pointed to `arc42-template.html` which doesn't exist in the build output.

## Root Cause
docToolchain generates individual arc42 chapter files (01_introduction.html, 02_constraints.html, etc.) rather than a single template file.

## Changes
Updated 2 broken links to point to the correct file:
- ❌ `arc42-template.html` → ✅ `arc42/01_introduction.html`

**Links Fixed:**
1. **Hero Section**: "Read Documentation" button
2. **Quick Start Section**: "Read the full documentation →" link

## Testing
- [x] Verified arc42/01_introduction.html exists in build output
- [x] Tested arc42 navigation link (already working)
- [ ] Visual verification pending deployment

## Notes
- Other links (GitHub, footer resources, arc42 nav) were already working correctly
- arc42/04_solution_strategy.html link ("Explore the Mental Model") also verified working

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>