### PR TITLE
Fix button contrast on colored backgrounds

### DIFF
--- a/docs/site/doc/landingpage.gsp
+++ b/docs/site/doc/landingpage.gsp
@@ -314,8 +314,8 @@ pip install -r requirements.txt</code></pre>
                     </div>
                 </div>
                 <div class="text-center mt-4">
-                    <a class="btn btn-outline-primary" href="${content.rootpath}arc42/04_solution_strategy.html">
-                        Explore the Mental Model →
+                    <a class="btn btn-lg btn-light" href="${content.rootpath}arc42/04_solution_strategy.html">
+                        <i class="fas fa-brain"></i> Explore the Mental Model →
                     </a>
                 </div>
             </div>
@@ -333,7 +333,7 @@ pip install -r requirements.txt</code></pre>
             <a class="btn btn-lg btn-primary me-3" href="https://github.com/raifdmueller/asciidoc-mcp">
                 <i class="fab fa-github"></i> Contribute on GitHub
             </a>
-            <a class="btn btn-lg btn-outline-primary" href="https://github.com/raifdmueller/asciidoc-mcp/issues">
+            <a class="btn btn-lg btn-light" href="https://github.com/raifdmueller/asciidoc-mcp/issues">
                 <i class="fas fa-bug"></i> Report Issues
             </a>
         </div>


### PR DESCRIPTION
## Summary
Fixes #22

## Problem
Two CTA buttons had very poor contrast on colored gradient backgrounds:
- **Architecture section**: Blue outline button on blue gradient → barely visible
- **Open Source section**: Red outline button on red gradient → barely visible

## Solution
Changed both buttons from `btn-outline-primary` to `btn-lg btn-light`:
- White buttons with high contrast on all colored backgrounds
- Consistent with hero section button styling (btn-light)
- Added brain icon to "Explore the Mental Model" for visual consistency

## Changes
1. **"Explore the Mental Model" button**: btn-outline-primary → btn-lg btn-light + icon
2. **"Report Issues" button**: btn-outline-primary → btn-lg btn-light

## Testing
- [ ] Visual verification pending deployment
- Expected: White buttons clearly visible on colored backgrounds

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>