### PR TITLE
feat: Add pagination support to all list-returning APIs (#32)

### DIFF
--- a/src/mcp_server.py
+++ b/src/mcp_server.py
@@ -89,9 +89,9 @@ class MCPDocumentationServer:
     # ============================================================================
 
     # DocumentAPI delegation methods
-    def get_structure(self, start_level: int = 1, parent_id: str = None):
+    def get_structure(self, start_level: int = 1, parent_id: str = None, limit: int = None, offset: int = 0):
         """Delegate to DocumentAPI"""
-        return self.doc_api.get_structure(start_level, parent_id)
+        return self.doc_api.get_structure(start_level, parent_id, limit, offset)
 
     def get_main_chapters(self):
         """Delegate to DocumentAPI"""


### PR DESCRIPTION
## Summary
Implements Issue #32: Adds comprehensive pagination support to all list-returning APIs with full backward compatibility.

## Changes

### New Pagination Helper
Created `_paginate()` helper method that handles:
- Limit/offset logic
- Pagination metadata generation
- Backward compatibility (limit=None returns all)

### Updated APIs
All three major list-returning APIs now support pagination:

1. **`search_content(query, limit, offset)`**
2. **`get_sections(level, limit, offset)`** 
3. **`get_structure(start_level, parent_id, limit, offset)`**

### Response Format
When `limit` is specified, returns:
```json
{
  "results": [ /* paginated items */ ],
  "pagination": {
    "total": 1000,
    "limit": 10,
    "offset": 0,
    "has_next": true,
    "has_previous": false
  }
}
```

When `limit` is `None` (default), returns original format for backward compatibility.

## Testing
✅ **All 65 tests passing** (+6 new pagination tests)

New test coverage:
- Pagination with limit/offset
- Page navigation (offset changes)
- Backward compatibility (no limit)
- limit=0 returns all results
- Pagination metadata accuracy

## Benefits

### 1. Token Efficiency
```python
# Before: Returns all 1000 results (token overflow!)
results = search_content("MCP")

# After: Returns manageable chunks
page1 = search_content("MCP", limit=10, offset=0)
page2 = search_content("MCP", limit=10, offset=10)
```

### 2. Performance
- Faster initial responses (smaller payloads)
- Works efficiently even with `offset=1000`
- No memory pressure from large result sets

### 3. Better UX
- Progressive loading in clients
- Pagination controls with `has_next`/`has_previous`
- Total count for UI display

## API Examples

### Search with Pagination
```python
result = search_content("architecture", limit=20, offset=0)
print(f"Showing {len(result['results'])} of {result['pagination']['total']}")
if result['pagination']['has_next']:
    next_page = search_content("architecture", limit=20, offset=20)
```

### Get Sections with Pagination
```python
# Get first 50 level-2 sections
page1 = get_sections(level=2, limit=50, offset=0)
```

### Get Structure with Pagination
```python
# Progressive TOC building
level1 = get_structure(start_level=1, limit=20)
level2 = get_structure(start_level=2, parent_id="intro", limit=50)
```

## Backward Compatibility

### Old Code Still Works ✅
```python
# No breaking changes - this still works exactly as before
results = search_content("query")  # Returns list
sections = get_sections(level=1)    # Returns list
structure = get_structure()         # Returns dict
```

### Migration Optional
Existing code doesn't need to change. Pagination is opt-in via `limit` parameter.

## References
- Fixes #32
- Addresses token limit issues from `docs/manual-test-report.adoc`

🤖 Generated with [Claude Code](https://claude.com/claude-code)