### PR TITLE
Fix: test_find_free_port_skips_used_ports mock patch path

### DIFF
--- a/tests/test_webserver_manager.py
+++ b/tests/test_webserver_manager.py
@@ -122,10 +122,10 @@ class TestWebserverManager:
         """Test find_free_port skips ports that are in use"""
         wm = WebserverManager(test_server)
 
-        # Mock socket to simulate port 8080 in use, 8081 free
-        with patch('socket.socket') as mock_socket_class:
+        # Mock socket in the webserver_manager module where it's imported
+        with patch('src.mcp.webserver_manager.socket.socket') as mock_socket_class:
             mock_socket = MagicMock()
-            mock_socket_class.return_value.__enter__.return_value = mock_socket
+            mock_socket_class.return_value = mock_socket
 
             # First attempt (8080) fails, second (8081) succeeds
             mock_socket.bind.side_effect = [OSError("Port in use"), None]


### PR DESCRIPTION
## Summary
• Fixed incorrect mock patch path in test that was causing test failure
• Mock now correctly intercepts socket calls in WebserverManager module

## Problem
The test `test_find_free_port_skips_used_ports` was failing because:
- Mock used `patch('socket.socket')` which doesn't intercept calls from imported modules
- WebserverManager imports socket directly, requiring module-specific patching

## Solution  
- Changed mock patch from `'socket.socket'` to `'src.mcp.webserver_manager.socket.socket'`
- Mock now correctly intercepts socket calls in the target module
- Test passes consistently with proper port conflict simulation

## Testing
- ✅ Target test now passes
- ✅ All WebserverManager tests continue to pass
- ✅ No regression in broader test suite

Closes #44